### PR TITLE
Changing Apache Kafka Labeling

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,6 @@ toc::[]
 == Datastores
 
 * https://calcite.apache.org/[Apache Calcite] - SQL parser, building blocks for datastores.
-* https://clickhouse.tech/[ClickHouse] - Open Source distributed column-oriented DBMS.
 * https://druid.apache.org/[Apache Druid] - A high performance real-time analytics database.
 * https://pinot.apache.org/[Apache Pinot] - A realtime distributed OLAP datastore.
 * https://www.influxdata.com/[InfluxDB] - Purpose-Built Open Source Time Series Database.
@@ -47,11 +46,12 @@ toc::[]
 == Integration
 
 * https://camel.apache.org/[Apache Camel] - Easily integrate various systems consuming or producing data.
+* https://kafka.apache.org/documentation/#connect[Kafka Connect] - Reusable framework to handle data int-and-out of Apache Kafka.
 
 == Messaging Infrastructure
 
 * https://activemq.apache.org/[Apache ActiveMQ] - Flexible & Powerful Multi-Protocol Messaging.
-* https://kafka.apache.org/[Apache Kafka] - A distributed commit log.
+* https://kafka.apache.org/[Apache Kafka] - A distributed commit log with pub-sub capabilities.
 * https://pulsar.apache.org/[Apache Pulsar] - A distributed pub-sub messaging system.
 * http://github.com/bsideup/liiklus[Liiklus] - An event gateway that provides reactive gRPC/RSocket access to Kafka-like systems.
 * https://nakadi.io/[Nakadi] - A distributed event bus that implements a RESTful API abstraction on top of Kafka-like queues].
@@ -67,9 +67,13 @@ toc::[]
 
 * https://beam.apache.org/[Apache Beam] - Implement batch and streaming data processing jobs that run on any execution engine.
 * https://flink.apache.org/[Apache Flink] - Stateful computations over data streams.
-* https://kafka.apache.org/documentation/streams/[Apache Kafka Streams] - A client library for building applications and microservices, where the input and output data are stored in Kafka clusters.
+* https://kafka.apache.org/documentation/streams/[Apache Kafka Streams] - A client library for building applications and microservices, where the input and output data are stored in Kafka.
 * http://samza.apache.org/[Apache Samza] - A distributed stream processing framework.
 * http://storm.apache.org/[Apache Storm] - A distributed realtime computation system.
+
+== Distributed Streaming Platform
+
+* https://kafka.apache.org/[Apache Kafka] - Building real-time event streaming apps using a combination of messaging, durable storage via the commit log, and stream processing capabilities.
 
 == Testing
 

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ toc::[]
 == Messaging Infrastructure
 
 * https://activemq.apache.org/[Apache ActiveMQ] - Flexible & Powerful Multi-Protocol Messaging.
-* https://kafka.apache.org/[Apache Kafka] - A distributed commit log with pub-sub capabilities.
+* https://kafka.apache.org/[Apache Kafka] - A distributed commit log with messaging capabilities.
 * https://pulsar.apache.org/[Apache Pulsar] - A distributed pub-sub messaging system.
 * http://github.com/bsideup/liiklus[Liiklus] - An event gateway that provides reactive gRPC/RSocket access to Kafka-like systems.
 * https://nakadi.io/[Nakadi] - A distributed event bus that implements a RESTful API abstraction on top of Kafka-like queues].
@@ -71,10 +71,6 @@ toc::[]
 * https://kafka.apache.org/documentation/streams/[Apache Kafka Streams] - A client library for building applications and microservices, where the input and output data are stored in Kafka.
 * http://samza.apache.org/[Apache Samza] - A distributed stream processing framework.
 * http://storm.apache.org/[Apache Storm] - A distributed realtime computation system.
-
-== Distributed Streaming Platform
-
-* https://kafka.apache.org/[Apache Kafka] - Building real-time event streaming apps using a combination of messaging, durable storage via the commit log, and stream processing capabilities.
 
 == Testing
 

--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,7 @@ toc::[]
 == Datastores
 
 * https://calcite.apache.org/[Apache Calcite] - SQL parser, building blocks for datastores.
+* https://clickhouse.tech/[ClickHouse] - Open Source distributed column-oriented DBMS.
 * https://druid.apache.org/[Apache Druid] - A high performance real-time analytics database.
 * https://pinot.apache.org/[Apache Pinot] - A realtime distributed OLAP datastore.
 * https://www.influxdata.com/[InfluxDB] - Purpose-Built Open Source Time Series Database.


### PR DESCRIPTION
As discussed [here](https://github.com/gunnarmorling/awesome-opensource-data-engineering/issues/4), I think Apache Kafka has a much broader representation within the open-source data engineering universe and therefore, this PR makes Kafka a bit more representative.

Thanks,

-- @riferrei